### PR TITLE
11 add optional arguments to pass in property and value

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,21 @@ A command-line interface (CLI) tool designed for seamless integration with Segme
 The CLI supports the following options:
 - `--apikey`: Your Segment Write Key (optional if provided during runtime).
 - `--file`: Path to the JSON file containing events (optional if provided during runtime).
-- 
+- `--payload`: JSON string to override event properties (optional).
+
 If you've installed the CLI globally, you can run it from anywhere:
 ``` ibm-segment --apikey YOUR_SEGMENT_WRITE_KEY --file PATH_TO_YOUR_EVENTS_FILE.json```
+
+
+### Overriding Event Properties
+You can override specific properties of the events by providing a JSON string with the `--payload` option. This is useful for setting or modifying properties like `userId` or `instanceId` directly from the command line.
+
+Example:
+```bash
+ibm-segment --apikey YOUR_SEGMENT_WRITE_KEY --file PATH_TO_YOUR_EVENTS_FILE.json --payload '{"userId":"joe@doe.com", "instanceId":"abc"}'
+```
+**Note:** Ensure your JSON string is correctly formatted. Incorrect JSON formats will result in an error, and the CLI will not proceed with tracking the events.
+
 
 From here you can select which events to fire from the JSON file. If no events are selected, all will be added.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ interface CommandLineOptions {
 }
 
 const argv = yargs(hideBin(process.argv))
-  .usage("Usage: $0 --apikey [string] --file [string]")
+  .usage("Usage: $0 --apikey [string] --file [string] --payload [json]")
   .option("apikey", {
     describe: "Your Segment Write Key",
     type: "string",
@@ -24,8 +24,14 @@ const argv = yargs(hideBin(process.argv))
     describe: "Path to the JSON file containing events",
     type: "string",
   })
+  .option("payload", {
+    describe: "JSON string containing event name and properties",
+    type: "string",
+  })
   .help("h")
-  .alias("h", "help").argv as unknown as CommandLineOptions;
+  .alias("h", "help").argv as unknown as CommandLineOptions & {
+    payload?: string;
+  };
 
 async function listEventGroups(filePath: string): Promise<string[]> {
   if (fs.lstatSync(filePath).isDirectory()) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,9 @@ const initCLI = async () => {
     try {
       payloadOverrides = JSON.parse(payload);
     } catch (error) {
-      console.error("Failed to parse payload:", error);
+      const errorMessage = (error instanceof Error) ? error.message : 'Unknown error';
+      console.error("Error parsing payload. Please ensure your JSON is correctly formatted. Example format: --payload '{\"key\":\"value\"}'");
+      console.error("Error details:", errorMessage);
       return;
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,7 +43,20 @@ async function listEventGroups(filePath: string): Promise<string[]> {
 }
 
 const initCLI = async () => {
-  let { apikey, file } = argv;
+  let { apikey, file, payload } = argv;
+
+  let payloadOverrides = {};
+
+  if (payload) {
+    try {
+      payloadOverrides = JSON.parse(payload);
+    } catch (error) {
+      console.error("Failed to parse payload:", error);
+      return;
+    }
+  }
+
+
 
   if (file) {
     try {
@@ -175,12 +188,15 @@ const initCLI = async () => {
 
     let parsedProps = JSON.parse(props);
 
+
     // extract out everything in props and put it into parsed props
     parsedProps = {
-      ...parsedProps.props,
+      ...parsedProps,
+      ...payloadOverrides,
       productCode: productCode,
       productCodeType: productCodeType,
     };
+    console.log(parsedProps)
     segmentTracker.track(event, parsedProps, userId);
   } while (trackAnother);
 };


### PR DESCRIPTION
allows for the payload to be overwritten using a --payload flag.
 ```ibm-segment --apikey ********** --file "/Users/ibm-segment/events.json" --payload '{"userId":"joe@doe.com", "instanceId": "abc"}'  ```
For example would override the userId and instanceId
closes #11 